### PR TITLE
fix: remove force namespace in command-line examples

### DIFF
--- a/messages/set.json
+++ b/messages/set.json
@@ -1,7 +1,7 @@
 {
   "description": "set username aliases for the Salesforce CLI\nYou can associate an alias with only one username at a time. If you’ve set an alias multiple times, the alias points to the most recent username.",
   "examples": [
-    "sfdx force:alias:set YourAlias=username@example.com",
-    "sfdx force:alias:set YourAlias=username@example.com YourOtherAlias=devhub@example.com"
+    "sfdx alias:set YourAlias=username@example.com",
+    "sfdx alias:set YourAlias=username@example.com YourOtherAlias=devhub@example.com"
   ]
 }


### PR DESCRIPTION
### What does this PR do?

Remove the "force:" namespace from the command-line examples

### What issues does this PR fix or reference?

n/a