### PR TITLE
test: oclif tables no longer show `undefined`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/cli/issues",
   "dependencies": {
-    "@oclif/core": "^1.9.0",
+    "@oclif/core": "^1.16.0",
     "@salesforce/command": "^5.0.0",
     "@salesforce/core": "^3.19.3",
     "chalk": "^4.1.2",

--- a/test/commands/alias/set.nut.ts
+++ b/test/commands/alias/set.nut.ts
@@ -90,7 +90,7 @@ describe('alias:set NUTs', async () => {
       expect(res).to.include('=== Alias Set');
       expect(res).to.include('Alias  Value');
       expect(res).to.include('DevHub');
-      expect(res).to.include('undefined');
+      expect(res).to.not.include('newdevhub@salesforce.com');
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -737,10 +737,10 @@
     is-wsl "^2.1.1"
     tslib "^2.3.1"
 
-"@oclif/core@^1.0.8", "@oclif/core@^1.2.1", "@oclif/core@^1.3.4", "@oclif/core@^1.3.6", "@oclif/core@^1.6.4", "@oclif/core@^1.7.0", "@oclif/core@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.npmjs.org/@oclif/core/-/core-1.9.0.tgz#bb2a7820a9176f28921f449c0f577d39c15e74d0"
-  integrity sha512-duvlaRQf4JM+mKuwwos1DNa/Q9x6tnF3khV5RU0fy5hhETF7THlTmxioKlIvKMyQDVpySqtZXZ0OKHeCi2EWuQ==
+"@oclif/core@^1.0.8", "@oclif/core@^1.16.0", "@oclif/core@^1.2.1", "@oclif/core@^1.3.4", "@oclif/core@^1.3.6", "@oclif/core@^1.6.4", "@oclif/core@^1.7.0":
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-1.16.0.tgz#4b53261eeb0c0244700bfc9eb41159d483436f21"
+  integrity sha512-xtqhAbjQHBcz+xQpEHJ3eJEVfRQ4zl41Yw5gw/N+D1jgaIUrHTxCY/sfTvhw93LAQo7B++ozHzSb7DISFXsQFQ==
   dependencies:
     "@oclif/linewrap" "^1.0.0"
     "@oclif/screen" "^3.0.2"


### PR DESCRIPTION
### What does this PR do?
nuts were failing because they asserted the presence of `undefined` which new oclif tables no longer use.  I changed that NUT to assert the lack of a value for that alias

How did this gt past the nuts here?  just-nuts caught it because the CLI is on a higher oclif (yarn deduplicate, etc) than the one here.  So I also bumped that.

@W-0@

### What issues does this 

PR fix or reference?
 fix https://app.circleci.com/pipelines/github/salesforcecli/plugin-alias/2835/workflows/74d01428-3589-4540-b99b-396863a71018/jobs/6256